### PR TITLE
add support for dynamic trace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/jussi-kalliokoski/slogdriver
 
 go 1.21
 
-require github.com/jussi-kalliokoski/goldjson v1.0.0 // indirect
+require github.com/jussi-kalliokoski/goldjson v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/jussi-kalliokoski/goldjson v0.0.0-20230613091353-057ded0698bb h1:7XODZ2DjK3gHJc+52VmwMzvU5gDcqgW0nDk0iQwZ0v0=
-github.com/jussi-kalliokoski/goldjson v0.0.0-20230613091353-057ded0698bb/go.mod h1:KHjhomAO4vlPukhBzc5nwIJ2nNL39TLnEgoIsBd8bnY=
 github.com/jussi-kalliokoski/goldjson v1.0.0 h1:XqiUNujQ3e9mjFPsqEBTzaMVPNnMUlXa+yDEVT4Xla0=
 github.com/jussi-kalliokoski/goldjson v1.0.0/go.mod h1:KHjhomAO4vlPukhBzc5nwIJ2nNL39TLnEgoIsBd8bnY=

--- a/handler.go
+++ b/handler.go
@@ -14,8 +14,9 @@ import (
 
 // Config defines the Stackdriver configuration.
 type Config struct {
-	ProjectID string
-	Level     slog.Leveler
+	ProjectID     string
+	Level         slog.Leveler
+	TraceProvider func(context.Context) Trace
 }
 
 // Handler is a handler that writes the log entries in the stackdriver logging
@@ -142,7 +143,11 @@ func (h *Handler) addSourceLocation(ctx context.Context, l *goldjson.LineWriter,
 }
 
 func (h *Handler) addTrace(ctx context.Context, l *goldjson.LineWriter, r *slog.Record) {
-	trace := traceFromContext(ctx)
+	traceProvider := traceFromContext
+	if h.config.TraceProvider != nil {
+		traceProvider = h.config.TraceProvider
+	}
+	trace := traceProvider(ctx)
 	if trace.ID == "" {
 		return
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -196,6 +196,73 @@ func TestHandler(t *testing.T) {
 					TraceSampled: vptr(false),
 				},
 			},
+			{
+				"dynamic no trace info",
+				slogdriver.Config{
+					TraceProvider: func(ctx context.Context) slogdriver.Trace { return slogdriver.Trace{} },
+				},
+				context.Background(),
+				TraceInfo{},
+			},
+			{
+				"dynamic span ID unavailable",
+				slogdriver.Config{
+					ProjectID: "jectpro",
+					TraceProvider: func(ctx context.Context) slogdriver.Trace {
+						return slogdriver.Trace{
+							ID: "def",
+						}
+					},
+				},
+				slogdriver.Trace{
+					ID: "abc",
+				}.Context(context.Background()),
+				TraceInfo{
+					TraceID:      vptr("projects/jectpro/traces/def"),
+					TraceSampled: vptr(false),
+				},
+			},
+			{
+				"dynamic sampled",
+				slogdriver.Config{
+					ProjectID: "ectproj",
+					TraceProvider: func(ctx context.Context) slogdriver.Trace {
+						return slogdriver.Trace{
+							ID:      "abc",
+							Sampled: true,
+						}
+					},
+				},
+				slogdriver.Trace{
+					ID:      "bcd",
+					Sampled: true,
+				}.Context(context.Background()),
+				TraceInfo{
+					TraceID:      vptr("projects/ectproj/traces/abc"),
+					TraceSampled: vptr(true),
+				},
+			},
+			{
+				"dynamic span ID",
+				slogdriver.Config{
+					ProjectID: "ctproje",
+					TraceProvider: func(ctx context.Context) slogdriver.Trace {
+						return slogdriver.Trace{
+							ID:     "abc",
+							SpanID: "foobaz",
+						}
+					},
+				},
+				slogdriver.Trace{
+					ID:     "cde",
+					SpanID: "foobar",
+				}.Context(context.Background()),
+				TraceInfo{
+					TraceID:      vptr("projects/ctproje/traces/abc"),
+					SpanID:       vptr("foobaz"),
+					TraceSampled: vptr(false),
+				},
+			},
 		}
 
 		for _, tt := range tests {


### PR DESCRIPTION
Adds an optional TraceProvider to the Config which will be used to extract a Trace from the current Context. This allows for using a standard telemetry library like otel by providing a wrapper to translate from their context to slogdriver's Trace. This has the benefit that slogdriver does not need to be notified if new trace spans are added through the telemetry library.